### PR TITLE
Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea/
 /target/
+/ObjectOrientedArchitectureDiagrammer.iml

--- a/src/main/java/model/diagram/ClassDiagram.java
+++ b/src/main/java/model/diagram/ClassDiagram.java
@@ -1,12 +1,11 @@
 package model.diagram;
 
-import model.diagram.graphml.GraphMLLeafEdge;
-import model.diagram.graphml.GraphMLLeafNode;
 import model.tree.node.Node;
 import model.tree.node.PackageNode;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class ClassDiagram extends Diagram {
 
@@ -23,9 +22,14 @@ public class ClassDiagram extends Diagram {
         return chosenClasses;
     }
 
-    public void createCollections() {
-        graphNodeCollection = new GraphMLLeafNode();
-        graphEdgeCollection = new GraphMLLeafEdge();
+    @Override
+    protected StringBuilder convertEdgesToGraphML() {
+        return graphEdgeCollection.convertLeafEdgesToGraphML();
+    }
+
+    @Override
+    protected StringBuilder convertNodesToGraphML(Map<Integer, List<Double>> nodesGeometry) {
+        return graphNodeCollection.convertLeafNodesToGraphML(nodesGeometry);
     }
 
 }

--- a/src/main/java/model/diagram/Diagram.java
+++ b/src/main/java/model/diagram/Diagram.java
@@ -33,7 +33,8 @@ public abstract class Diagram {
     }
 
     public Map<String, Map<String, String>> createDiagram(List<String> chosenFilesNames) {
-        createCollections();
+        graphNodeCollection = new GraphNodeCollection();
+        graphEdgeCollection = new GraphEdgeCollection(graphNodeCollection.getGraphNodes());
         graphNodeCollection.populateGraphNodes(getChosenNodes(chosenFilesNames));
         graphEdgeCollection.setGraphNodes(graphNodeCollection.getGraphNodes());
         graphEdgeCollection.populateGraphEdges(getChosenNodes(chosenFilesNames));
@@ -48,12 +49,12 @@ public abstract class Diagram {
     }
 
     public File exportDiagramToGraphML(Path graphMLSavePath) {
-        graphNodeCollection.convertNodesToGraphML(nodesGeometry);
-        graphEdgeCollection.convertEdgesToGraphML();
+        convertNodesToGraphML(nodesGeometry);
+        convertEdgesToGraphML();
         GraphMLExporter graphMLExporter = new GraphMLExporter();
         return graphMLExporter.exportDiagramToGraphML(graphMLSavePath, graphNodeCollection.getGraphMLBuffer(), graphEdgeCollection.getGraphMLBuffer());
     }
-    
+
     public void exportPlantUMLDiagram(Path graphSavePath) {
     	boolean packageDiagram;
     	graphNodeCollection.convertNodesToPlantUML();
@@ -62,7 +63,7 @@ public abstract class Diagram {
     	PlantUMLExporter plantUMLExporter = new PlantUMLExporter();
     	plantUMLExporter.exportDiagram(graphSavePath, graphNodeCollection.getPlantUMLBuffer(), graphEdgeCollection.getPlantUMLBuffer(), packageDiagram);
     }
-    
+
     public void exportPlantUMLText(Path textSavePath) {
     	boolean packageDiagram;
     	graphNodeCollection.convertNodesToPlantUML();
@@ -71,7 +72,7 @@ public abstract class Diagram {
     	PlantUMLExporter plantUMLExporter = new PlantUMLExporter();
     	plantUMLExporter.exportText(textSavePath, graphNodeCollection.getPlantUMLBuffer(), graphEdgeCollection.getPlantUMLBuffer(), packageDiagram);
     }
-    
+
     public File saveDiagram(Path graphSavePath) {
         JavaFXExporter javaFXExporter = new JavaFXExporter();
         return javaFXExporter.saveDiagram(createdDiagram, graphSavePath);
@@ -93,8 +94,10 @@ public abstract class Diagram {
         return javaFXVisualization.createGraphView(createdDiagram);
     }
 
-    public abstract List<Node> getChosenNodes(List<String> chosenFileNames);
+    protected abstract StringBuilder convertEdgesToGraphML();
 
-    public abstract void createCollections();
+    protected abstract StringBuilder convertNodesToGraphML(Map<Integer, List<Double>> nodesGeometry);
+
+    public abstract List<Node> getChosenNodes(List<String> chosenFileNames);
 
 }

--- a/src/main/java/model/diagram/GraphEdgeCollection.java
+++ b/src/main/java/model/diagram/GraphEdgeCollection.java
@@ -1,5 +1,7 @@
 package model.diagram;
 
+import model.diagram.graphml.GraphMLLeafEdge;
+import model.diagram.graphml.GraphMLPackageEdge;
 import model.tree.node.Node;
 import model.tree.edge.Relationship;
 
@@ -8,7 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class GraphEdgeCollection {
+public class GraphEdgeCollection {
 
     private final Map<Relationship, Integer> graphEdges;
     protected Map<Node, Integer> graphNodes;
@@ -17,7 +19,8 @@ public abstract class GraphEdgeCollection {
     private final List<String> plantUMLTester;
     private int edgeId;
 
-    public GraphEdgeCollection() {
+    public GraphEdgeCollection(Map<Node, Integer> graphNodes) {
+        this.graphNodes = graphNodes;
         graphEdges = new HashMap<>();
         graphMLBuffer = new StringBuilder();
         plantUMLTester = new ArrayList<>();
@@ -73,15 +76,24 @@ public abstract class GraphEdgeCollection {
 
     public String getPlantUMLBuffer() { return plantUMLBuffer.toString(); }
     
-    public StringBuilder convertEdgesToGraphML(){
+    public StringBuilder convertLeafEdgesToGraphML(){
+        GraphMLLeafEdge graphMLLeafEdge = new GraphMLLeafEdge(graphNodes);
         for (Map.Entry<Relationship, Integer> entry: graphEdges.entrySet()) {
-            graphMLBuffer.append(convertEdge(entry.getKey(), entry.getValue()));
+            graphMLBuffer.append(graphMLLeafEdge.convertEdge(entry.getKey(), entry.getValue()));
         }
         return graphMLBuffer;
     }
 
-    public abstract String convertEdge(Relationship relationship, int edgeId);
-    
+    public StringBuilder convertPackageEdgesToGraphML(){
+        GraphMLPackageEdge graphMLPackageEdge = new GraphMLPackageEdge(graphNodes);
+        for (Map.Entry<Relationship, Integer> entry: graphEdges.entrySet()) {
+            graphMLBuffer.append(graphMLPackageEdge.convertEdge(entry.getKey(), entry.getValue()));
+        }
+        return graphMLBuffer;
+    }
+
+    //public abstract String convertEdge(Relationship relationship, int edgeId);
+
     private String transformPlantUMLRelationship(String Relationship) {
     	switch (Relationship) {
     		case "EXTENSION":

--- a/src/main/java/model/diagram/GraphNodeCollection.java
+++ b/src/main/java/model/diagram/GraphNodeCollection.java
@@ -1,6 +1,8 @@
 package model.diagram;
 
 
+import model.diagram.graphml.GraphMLLeafNode;
+import model.diagram.graphml.GraphMLPackageNode;
 import model.tree.node.Node;
 import model.tree.node.LeafNode;
 import model.tree.node.NodeType;
@@ -10,10 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class GraphNodeCollection {
-
-    protected static final int X_COORDINATE = 0;
-    protected static final int Y_COORDINATE = 1;
+public class GraphNodeCollection {
 
     private final Map<Node, Integer> graphNodes;
     private final StringBuilder graphMLBuffer;
@@ -36,13 +35,22 @@ public abstract class GraphNodeCollection {
         }
     }
 
-    public StringBuilder convertNodesToGraphML(Map<Integer, List<Double>> nodesGeometry) {
+    public StringBuilder convertLeafNodesToGraphML(Map<Integer, List<Double>> nodesGeometry) {
+		GraphMLLeafNode graphMLLeafNode = new GraphMLLeafNode();
         for (Map.Entry<Node, Integer> entry: graphNodes.entrySet()) {
-            graphMLBuffer.append(convertNode(entry.getKey(), entry.getValue(), nodesGeometry.get(entry.getValue())));
+            graphMLBuffer.append(graphMLLeafNode.convertNode(entry.getKey(), entry.getValue(), nodesGeometry.get(entry.getValue())));
         }
         return graphMLBuffer;
     }
-    
+
+	public StringBuilder convertPackageNodesToGraphML(Map<Integer, List<Double>> nodesGeometry) {
+		GraphMLPackageNode graphMLPackageNode = new GraphMLPackageNode();
+        for (Map.Entry<Node, Integer> entry: graphNodes.entrySet()) {
+            graphMLBuffer.append(graphMLPackageNode.convertNode(entry.getKey(), entry.getValue(), nodesGeometry.get(entry.getValue())));
+        }
+        return graphMLBuffer;
+    }
+
     public Map<String, String> convertNodesToPlantUML() {
     	StringBuilder plantUMLDeclarations = new StringBuilder();
     	plantUMLBuffer = new StringBuilder();
@@ -108,7 +116,7 @@ public abstract class GraphNodeCollection {
     
     public String getPlantUMLBuffer(){ return plantUMLBuffer.toString(); }    
 
-    public abstract String convertNode(Node node, int nodeId, List<Double> nodesGeometry);
+    // public abstract String convertNode(Node node, int nodeId, List<Double> nodesGeometry);
     
     private String visibilityToPlantUML(String visibility) {
 		return switch (visibility) {

--- a/src/main/java/model/diagram/PackageDiagram.java
+++ b/src/main/java/model/diagram/PackageDiagram.java
@@ -1,32 +1,37 @@
 package model.diagram;
 
-import model.diagram.graphml.GraphMLPackageEdge;
-import model.diagram.graphml.GraphMLPackageNode;
 import model.tree.node.Node;
 
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class PackageDiagram extends Diagram {
 
     public List<Node> getChosenNodes(List<String> chosenPackagesNames) {
         List<Node> chosenPackages = new ArrayList<>();
         for (String chosenPackage: chosenPackagesNames) {
-            if (isPackageValid(chosenPackage)) {
-                chosenPackages.add(sourceProject.getPackageNodes().get(Paths.get(chosenPackage)));
+            if (!isPackageValid(chosenPackage)) {
+                continue;
             }
+            chosenPackages.add(sourceProject.getPackageNodes().get(Paths.get(chosenPackage)));
         }
         return chosenPackages;
     }
 
-    public void createCollections() {
-        graphNodeCollection = new GraphMLPackageNode();
-        graphEdgeCollection = new GraphMLPackageEdge();
-    }
-
     private boolean isPackageValid(String chosenPackage) {
         return sourceProject.getPackageNodes().get(Paths.get(chosenPackage)).isValid();
+    }
+
+    @Override
+    protected StringBuilder convertEdgesToGraphML() {
+        return graphEdgeCollection.convertPackageEdgesToGraphML();
+    }
+
+    @Override
+    protected StringBuilder convertNodesToGraphML(Map<Integer, List<Double>> nodesGeometry) {
+        return graphNodeCollection.convertPackageNodesToGraphML(nodesGeometry);
     }
 
 }

--- a/src/main/java/model/diagram/graphml/GraphMLLeafEdge.java
+++ b/src/main/java/model/diagram/graphml/GraphMLLeafEdge.java
@@ -1,16 +1,22 @@
 package model.diagram.graphml;
 
-import model.diagram.GraphEdgeCollection;
 import model.tree.edge.Relationship;
+import model.tree.node.Node;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
-public class GraphMLLeafEdge extends GraphEdgeCollection {
+public class GraphMLLeafEdge {
 
     private static final int EDGE_TYPE = 0;
     private static final int EDGES_SOURCE_TYPE = 1;
     private static final int EDGES_TARGET_TYPE = 2;
+    private final Map<Node, Integer> graphNodes;
+
+    public GraphMLLeafEdge(Map<Node, Integer> graphNodes) {
+        this.graphNodes = graphNodes;
+    }
 
     public String convertEdge(Relationship relationship, int edgeId) {
         return GraphMLSyntax.getInstance().getGraphMLEdgesSyntax(getEdgesProperties(relationship, edgeId));
@@ -23,18 +29,13 @@ public class GraphMLLeafEdge extends GraphEdgeCollection {
     }
 
     private List<String> identifyEdgeType(Relationship relationship){
-        switch (relationship.getRelationshipType()) {
-            case DEPENDENCY:
-                return Arrays.asList("dashed", "none", "plain");
-            case AGGREGATION:
-                return Arrays.asList("line", "white_diamond", "none");
-            case ASSOCIATION:
-                return Arrays.asList("line", "none", "standard");
-            case EXTENSION:
-                return Arrays.asList("line", "none", "white_delta");
-            default:
-                return Arrays.asList("dashed", "none", "white_delta");
-        }
+        return switch (relationship.getRelationshipType()) {
+            case DEPENDENCY -> Arrays.asList("dashed", "none", "plain");
+            case AGGREGATION -> Arrays.asList("line", "white_diamond", "none");
+            case ASSOCIATION -> Arrays.asList("line", "none", "standard");
+            case EXTENSION -> Arrays.asList("line", "none", "white_delta");
+            default -> Arrays.asList("dashed", "none", "white_delta");
+        };
     }
 
 }

--- a/src/main/java/model/diagram/graphml/GraphMLLeafNode.java
+++ b/src/main/java/model/diagram/graphml/GraphMLLeafNode.java
@@ -1,6 +1,5 @@
 package model.diagram.graphml;
 
-import model.diagram.GraphNodeCollection;
 import model.tree.node.LeafNode;
 import model.tree.node.Node;
 import model.tree.node.NodeType;
@@ -9,10 +8,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-public class GraphMLLeafNode extends GraphNodeCollection {
+public class GraphMLLeafNode {
 
     private static final String CLASS_COLOR = "#FF9900";
     private static final String INTERFACE_COLOR = "#3366FF";
+    private static final int X_COORDINATE = 0;
+    private static final int Y_COORDINATE = 1;
+
+    public GraphMLLeafNode() {
+    }
 
     public String convertNode(Node leafNode, int nodeId, List<Double> nodeGeometry) {
         return GraphMLSyntax.getInstance().getGraphMLNodesSyntax(getNodesDescription((LeafNode) leafNode, nodeId, nodeGeometry));

--- a/src/main/java/model/diagram/graphml/GraphMLPackageEdge.java
+++ b/src/main/java/model/diagram/graphml/GraphMLPackageEdge.java
@@ -1,12 +1,19 @@
 package model.diagram.graphml;
 
-import model.diagram.GraphEdgeCollection;
 import model.tree.edge.Relationship;
+import model.tree.node.Node;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
-public class GraphMLPackageEdge extends GraphEdgeCollection {
+public class GraphMLPackageEdge {
+    private final Map<Node, Integer> graphNodes;
+
+    public GraphMLPackageEdge(Map<Node, Integer> graphNodes) {
+
+        this.graphNodes = graphNodes;
+    }
 
     public String convertEdge(Relationship relationship, int edgeId) {
         return GraphMLSyntax.getInstance().getGraphMLPackageEdgesSyntax(getEdgesProperties(relationship, edgeId));

--- a/src/main/java/model/diagram/graphml/GraphMLPackageNode.java
+++ b/src/main/java/model/diagram/graphml/GraphMLPackageNode.java
@@ -1,13 +1,15 @@
 package model.diagram.graphml;
 
-import model.diagram.GraphNodeCollection;
 import model.tree.node.Node;
 import model.tree.node.PackageNode;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class GraphMLPackageNode extends GraphNodeCollection {
+public class GraphMLPackageNode {
+
+    private static final int X_COORDINATE = 0;
+    private static final int Y_COORDINATE = 1;
 
     public String convertNode(Node packageNode, int nodeId, List<Double> nodeGeometry) {
         return GraphMLSyntax.getInstance().getGraphMLPackageNodesSyntax(getNodesDescription((PackageNode)packageNode,

--- a/src/test/java/manager/diagram/ClassDiagramManagerTest.java
+++ b/src/test/java/manager/diagram/ClassDiagramManagerTest.java
@@ -57,8 +57,8 @@ public class ClassDiagramManagerTest {
         SourceProject sourceProject = classDiagramManager.createTree(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
         Map<String, Map<String, String>> testingCreatedDiagram = classDiagramManager.createDiagram(chosenFiles);
 
-        GraphNodeCollection graphNodeCollection = new GraphMLLeafNode();
-        GraphEdgeCollection graphEdgeCollection = new GraphMLLeafEdge();
+        GraphNodeCollection graphNodeCollection = new GraphNodeCollection();
+        GraphEdgeCollection graphEdgeCollection = new GraphEdgeCollection(graphNodeCollection.getGraphNodes());
         graphNodeCollection.populateGraphNodes(getChosenNodes(chosenFiles, sourceProject));
         graphEdgeCollection.setGraphNodes(graphNodeCollection.getGraphNodes());
         graphEdgeCollection.populateGraphEdges(getChosenNodes(chosenFiles, sourceProject));
@@ -85,8 +85,8 @@ public class ClassDiagramManagerTest {
 
         File testingExportedFile = classDiagramManager.exportDiagramToGraphML(Paths.get(System.getProperty("user.home")+"\\testingExportedFile.graphML"));
 
-        GraphNodeCollection graphNodeCollection = new GraphMLLeafNode();
-        GraphEdgeCollection graphEdgeCollection = new GraphMLLeafEdge();
+        GraphNodeCollection graphNodeCollection = new GraphNodeCollection();
+        GraphEdgeCollection graphEdgeCollection = new GraphEdgeCollection(graphNodeCollection.getGraphNodes());
         graphNodeCollection.populateGraphNodes(getChosenNodes(chosenFiles, sourceProject));
         graphEdgeCollection.setGraphNodes(graphNodeCollection.getGraphNodes());
         graphEdgeCollection.populateGraphEdges(getChosenNodes(chosenFiles, sourceProject));
@@ -94,8 +94,8 @@ public class ClassDiagramManagerTest {
         DiagramArrangement diagramArrangement = new DiagramArrangement();
         Map<Integer, List<Double>> nodesGeometry = diagramArrangement.arrangeDiagram(graphNodeCollection.getGraphNodes(), graphEdgeCollection.getGraphEdges());
 
-        graphNodeCollection.convertNodesToGraphML(nodesGeometry);
-        graphEdgeCollection.convertEdgesToGraphML();
+        graphNodeCollection.convertLeafNodesToGraphML(nodesGeometry);
+        graphEdgeCollection.convertLeafEdgesToGraphML();
         GraphMLExporter graphMLExporter = new GraphMLExporter();
 
         try {

--- a/src/test/java/model/CollectionsDiagramConvertTest.java
+++ b/src/test/java/model/CollectionsDiagramConvertTest.java
@@ -30,8 +30,8 @@ public class CollectionsDiagramConvertTest {
         List<String> chosenFiles = Arrays.asList("MainWindow", "LatexEditorView", "OpeningWindow");
         SourceProject sourceProject = classDiagramManager.createTree(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
 
-        GraphNodeCollection graphNodeCollection = new GraphMLLeafNode();
-        GraphEdgeCollection graphEdgeCollection = new GraphMLLeafEdge();
+        GraphNodeCollection graphNodeCollection = new GraphNodeCollection();
+        GraphEdgeCollection graphEdgeCollection = new GraphEdgeCollection(graphNodeCollection.getGraphNodes());
         graphNodeCollection.populateGraphNodes(getChosenNodes(chosenFiles, sourceProject));
         graphEdgeCollection.setGraphNodes(graphNodeCollection.getGraphNodes());
         graphEdgeCollection.populateGraphEdges(getChosenNodes(chosenFiles, sourceProject));

--- a/src/test/java/model/GraphMLConverterTest.java
+++ b/src/test/java/model/GraphMLConverterTest.java
@@ -1,5 +1,6 @@
 package model;
 
+import model.diagram.GraphEdgeCollection;
 import model.diagram.GraphNodeCollection;
 import model.diagram.graphml.GraphMLLeafEdge;
 import model.diagram.graphml.GraphMLLeafNode;
@@ -31,7 +32,7 @@ class GraphMLConverterTest {
     @Test
     void populateGraphMLNodesTest() throws IOException {
         for (ParserType parserType: parserTypes) {
-            GraphNodeCollection graphMLNode = new GraphMLLeafNode();
+            GraphNodeCollection graphMLNode = new GraphNodeCollection();
             Parser parser = new ProjectParser(parserType);
             parser.parseSourcePackage(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
             graphMLNode.populateGraphNodes(new ArrayList<>(parser.getPackageNodes().get(Paths.get(currentDirectory.toRealPath().normalize().toString(),
@@ -57,13 +58,13 @@ class GraphMLConverterTest {
     @Test
     void convertNodesToGraphMLTest() throws IOException {
         for (ParserType parserType: parserTypes) {
-            GraphNodeCollection graphMLNode = new GraphMLLeafNode();
+            GraphNodeCollection graphMLNode = new GraphNodeCollection();
             Parser parser = new ProjectParser(parserType);
             parser.parseSourcePackage(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
             graphMLNode.populateGraphNodes(new ArrayList<>(parser.getPackageNodes().get(Paths.get(currentDirectory.toRealPath().normalize().toString(),
                     "\\src\\test\\resources\\LatexEditor\\src\\controller\\commands")).getLeafNodes().values()));
             StringBuilder expected = new StringBuilder();
-            StringBuilder actual = graphMLNode.convertNodesToGraphML(Map.ofEntries(
+            StringBuilder actual = graphMLNode.convertLeafNodesToGraphML(Map.ofEntries(
                     Map.entry(0, Arrays.asList(10.0, 10.0)),
                     Map.entry(1, Arrays.asList(10.0, 10.0)),
                     Map.entry(2, Arrays.asList(10.0, 10.0)),
@@ -103,14 +104,14 @@ class GraphMLConverterTest {
     @Test
     void populateGraphMLEdgesTest() throws IOException {
         for (ParserType parserType: parserTypes) {
-            GraphNodeCollection graphMLNode = new GraphMLLeafNode();
+            GraphNodeCollection graphMLNode = new GraphNodeCollection();
             Parser parser = new ProjectParser(parserType);
             parser.parseSourcePackage(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
             graphMLNode.populateGraphNodes(new ArrayList<>(parser.getPackageNodes().get(Paths.get(currentDirectory.toRealPath().normalize().toString(),
                     "\\src\\test\\resources\\LatexEditor\\src\\controller\\commands")).getLeafNodes().values()));
-            GraphMLLeafEdge graphMLEdge = new GraphMLLeafEdge();
-            graphMLEdge.setGraphNodes(graphMLNode.getGraphNodes());
-            graphMLEdge.populateGraphEdges(new ArrayList<>(parser.getPackageNodes().get(Paths.get(currentDirectory.toRealPath().normalize().toString(),
+            GraphMLLeafEdge graphMLEdge = new GraphMLLeafEdge(graphMLNode.getGraphNodes());
+            GraphEdgeCollection graphEdgeCollection = new GraphEdgeCollection(graphMLNode.getGraphNodes());
+            graphEdgeCollection.populateGraphEdges(new ArrayList<>(parser.getPackageNodes().get(Paths.get(currentDirectory.toRealPath().normalize().toString(),
                     "\\src\\test\\resources\\LatexEditor\\src\\controller\\commands")).getLeafNodes().values()));
             List<Relationship> relationships = new ArrayList<>();
 
@@ -123,7 +124,7 @@ class GraphMLConverterTest {
                     relationships.add(relationship);
                 }
             }
-            for (Map.Entry<Relationship, Integer> e: graphMLEdge.getGraphEdges().entrySet()) {
+            for (Map.Entry<Relationship, Integer> e: graphEdgeCollection.getGraphEdges().entrySet()) {
                 String edgesStart = e.getKey().getStartingNode().getName();
                 String edgesEnd = e.getKey().getEndingNode().getName();
                 boolean foundBranch = false;
@@ -145,16 +146,17 @@ class GraphMLConverterTest {
     @Test
     void convertEdgesToGraphML() throws IOException {
         for (ParserType parserType: parserTypes) {
-            GraphNodeCollection graphMLNode = new GraphMLLeafNode();
+            GraphNodeCollection graphMLNode = new GraphNodeCollection();
             Parser parser = new ProjectParser(parserType);
             parser.parseSourcePackage(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
             graphMLNode.populateGraphNodes(new ArrayList<>(parser.getPackageNodes().get(Paths.get(currentDirectory.toRealPath().normalize().toString(),
                     "\\src\\test\\resources\\LatexEditor\\src\\controller\\commands")).getLeafNodes().values()));
-            GraphMLLeafEdge graphMLEdge = new GraphMLLeafEdge();
-            graphMLEdge.setGraphNodes(graphMLNode.getGraphNodes());
-            graphMLEdge.populateGraphEdges(new ArrayList<>(parser.getPackageNodes().get(Paths.get(currentDirectory.toRealPath().normalize().toString(),
+            GraphMLLeafEdge graphMLEdge = new GraphMLLeafEdge(graphMLNode.getGraphNodes());
+            GraphEdgeCollection graphEdgeCollection = new GraphEdgeCollection(graphMLNode.getGraphNodes());
+            graphEdgeCollection.setGraphNodes(graphMLNode.getGraphNodes());
+            graphEdgeCollection.populateGraphEdges(new ArrayList<>(parser.getPackageNodes().get(Paths.get(currentDirectory.toRealPath().normalize().toString(),
                     "\\src\\test\\resources\\LatexEditor\\src\\controller\\commands")).getLeafNodes().values()));
-            StringBuilder actual = graphMLEdge.convertEdgesToGraphML();
+            StringBuilder actual = graphEdgeCollection.convertLeafEdgesToGraphML();
 
             StringBuilder expected = new StringBuilder();
             List<Relationship> relationships = new ArrayList<>();
@@ -167,7 +169,7 @@ class GraphMLConverterTest {
                     relationships.add(relationship);
                 }
             }
-            for (Map.Entry<Relationship, Integer> e: graphMLEdge.getGraphEdges().entrySet()) {
+            for (Map.Entry<Relationship, Integer> e: graphEdgeCollection.getGraphEdges().entrySet()) {
                 String edgesStart = e.getKey().getStartingNode().getName();
                 String edgesEnd = e.getKey().getEndingNode().getName();
                 for (Relationship relationship: relationships) {
@@ -194,7 +196,7 @@ class GraphMLConverterTest {
     @Test
     void populateGraphMLPackageNodeTest() throws IOException {
         for (ParserType parserType: parserTypes) {
-            GraphNodeCollection graphMLPackageNode = new GraphMLPackageNode();
+            GraphNodeCollection graphMLPackageNode = new GraphNodeCollection();
             Parser parser = new ProjectParser(parserType);
             parser.parseSourcePackage(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
             graphMLPackageNode.populateGraphNodes(new ArrayList<>(parser.getPackageNodes().values()));
@@ -221,13 +223,13 @@ class GraphMLConverterTest {
     @Test
     void convertPackageNodesToGraphMLTest() throws IOException {
         for (ParserType parserType: parserTypes) {
-            GraphNodeCollection graphMLPackageNode = new GraphMLPackageNode();
+            GraphNodeCollection graphMLPackageNode = new GraphNodeCollection();
             Parser parser = new ProjectParser(parserType);
             parser.parseSourcePackage(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
             graphMLPackageNode.populateGraphNodes(new ArrayList<>(parser.getPackageNodes().values()));
 
             StringBuilder expected = new StringBuilder();
-            graphMLPackageNode.convertNodesToGraphML(Map.ofEntries(
+            graphMLPackageNode.convertPackageNodesToGraphML(Map.ofEntries(
                     Map.entry(0, Arrays.asList(10.0, 10.0)),
                     Map.entry(1, Arrays.asList(10.0, 10.0)),
                     Map.entry(2, Arrays.asList(10.0, 10.0)),
@@ -257,14 +259,15 @@ class GraphMLConverterTest {
     @Test
     void populateGraphMLPackageEdgesTest() throws IOException {
         for (ParserType parserType: parserTypes) {
-            GraphNodeCollection graphMLPackageNode = new GraphMLPackageNode();
+            GraphNodeCollection graphMLPackageNode = new GraphNodeCollection();
             Parser parser = new ProjectParser(parserType);
             parser.parseSourcePackage(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
             graphMLPackageNode.populateGraphNodes(new ArrayList<>(parser.getPackageNodes().values()));
 
-            GraphMLPackageEdge graphMLPackageEdge = new GraphMLPackageEdge();
-            graphMLPackageEdge.setGraphNodes(graphMLPackageNode.getGraphNodes());
-            graphMLPackageEdge.populateGraphEdges(new ArrayList<>(parser.getPackageNodes().values()));
+            GraphMLPackageEdge graphMLPackageEdge = new GraphMLPackageEdge(graphMLPackageNode.getGraphNodes());
+            GraphEdgeCollection graphEdgeCollection = new GraphEdgeCollection(graphMLPackageNode.getGraphNodes());
+            graphEdgeCollection.setGraphNodes(graphMLPackageNode.getGraphNodes());
+            graphEdgeCollection.populateGraphEdges(new ArrayList<>(parser.getPackageNodes().values()));
 
             List<Relationship> relationships = new ArrayList<>();
 
@@ -272,7 +275,7 @@ class GraphMLConverterTest {
                 relationships.addAll(packageNode.getNodeRelationships());
             }
 
-            for (Map.Entry<Relationship, Integer> e : graphMLPackageEdge.getGraphEdges().entrySet()) {
+            for (Map.Entry<Relationship, Integer> e : graphEdgeCollection.getGraphEdges().entrySet()) {
                 String edgesStart = e.getKey().getStartingNode().getName();
                 String edgesEnd = e.getKey().getEndingNode().getName();
                 boolean foundBranch = false;
@@ -289,16 +292,17 @@ class GraphMLConverterTest {
     @Test
     void convertPackageEdgesToGraphMLTest() throws IOException {
         for (ParserType parserType: parserTypes) {
-            GraphNodeCollection graphMLPackageNode = new GraphMLPackageNode();
+            GraphNodeCollection graphMLPackageNode = new GraphNodeCollection();
             Parser parser = new ProjectParser(parserType);
             parser.parseSourcePackage(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
             StringBuilder expected = new StringBuilder();
             graphMLPackageNode.populateGraphNodes(new ArrayList<>(parser.getPackageNodes().values()));
 
-            GraphMLPackageEdge graphMLPackageEdge = new GraphMLPackageEdge();
-            graphMLPackageEdge.setGraphNodes(graphMLPackageNode.getGraphNodes());
-            graphMLPackageEdge.populateGraphEdges(new ArrayList<>(parser.getPackageNodes().values()));
-            graphMLPackageEdge.convertEdgesToGraphML();
+            GraphMLPackageEdge graphMLPackageEdge = new GraphMLPackageEdge(graphMLPackageNode.getGraphNodes());
+            GraphEdgeCollection graphEdgeCollection = new GraphEdgeCollection(graphMLPackageNode.getGraphNodes());
+            graphEdgeCollection.setGraphNodes(graphMLPackageNode.getGraphNodes());
+            graphEdgeCollection.populateGraphEdges(new ArrayList<>(parser.getPackageNodes().values()));
+            graphEdgeCollection.convertPackageEdgesToGraphML();
 
             List<Relationship> relationships = new ArrayList<>();
 
@@ -306,7 +310,7 @@ class GraphMLConverterTest {
                 relationships.addAll(packageNode.getNodeRelationships());
             }
 
-            for (Map.Entry<Relationship, Integer> e : graphMLPackageEdge.getGraphEdges().entrySet()) {
+            for (Map.Entry<Relationship, Integer> e : graphEdgeCollection.getGraphEdges().entrySet()) {
                 String edgesStart = e.getKey().getStartingNode().getName();
                 String edgesEnd = e.getKey().getEndingNode().getName();
                 for (Relationship relationship : relationships) {
@@ -326,7 +330,7 @@ class GraphMLConverterTest {
                     }
                 }
             }
-            assertEquals(expected.toString(), graphMLPackageEdge.getGraphMLBuffer());
+            assertEquals(expected.toString(), graphEdgeCollection.getGraphMLBuffer());
         }
     }
 
@@ -336,18 +340,13 @@ class GraphMLConverterTest {
                 identifyEdgeType(relationship).get(1), identifyEdgeType(relationship).get(2));
     }
     private List<String> identifyEdgeType(Relationship relationship){
-        switch (relationship.getRelationshipType()) {
-            case DEPENDENCY:
-                return Arrays.asList("dashed", "none", "plain");
-            case AGGREGATION:
-                return Arrays.asList("line", "white_diamond", "none");
-            case ASSOCIATION:
-                return Arrays.asList("line", "none", "standard");
-            case EXTENSION:
-                return Arrays.asList("line", "none", "white_delta");
-            default:
-                return Arrays.asList("dashed", "none", "white_delta");
-        }
+        return switch (relationship.getRelationshipType()) {
+            case DEPENDENCY -> Arrays.asList("dashed", "none", "plain");
+            case AGGREGATION -> Arrays.asList("line", "white_diamond", "none");
+            case ASSOCIATION -> Arrays.asList("line", "none", "standard");
+            case EXTENSION -> Arrays.asList("line", "none", "white_delta");
+            default -> Arrays.asList("dashed", "none", "white_delta");
+        };
     }
     public static <T, E> T getKeyByValue(Map<T, E> map, E value) {
         for (Map.Entry<T, E> entry : map.entrySet()) {

--- a/src/test/java/model/PlantUMLConverterTest.java
+++ b/src/test/java/model/PlantUMLConverterTest.java
@@ -45,8 +45,8 @@ class PlantUMLConverterTest {
 		expectedRelationships.add("DocumentManager --o Document");
 		expectedRelationships.add("StableVersionsStrategy ..> Document");
 		expectedRelationships.add("VersionsStrategy ..> Document");
-		GraphNodeCollection graphNodeCollection = new GraphMLLeafNode();
-		GraphEdgeCollection graphEdgeCollection = new GraphMLLeafEdge();
+		GraphNodeCollection graphNodeCollection = new GraphNodeCollection();
+		GraphEdgeCollection graphEdgeCollection = new GraphEdgeCollection(graphNodeCollection.getGraphNodes());
         Parser parser = new ProjectParser(parserType);
         parser.parseSourcePackage(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
         graphNodeCollection.populateGraphNodes(new ArrayList<>(parser.getPackageNodes().get(Paths.get(currentDirectory.toRealPath().normalize().toString(),
@@ -140,7 +140,7 @@ class PlantUMLConverterTest {
 				+ "+setCurrentVersion(Document document): void\n"
 				+ "}\n");
 		
-		GraphNodeCollection graphNodeCollection = new GraphMLLeafNode();
+		GraphNodeCollection graphNodeCollection = new GraphNodeCollection();
         Parser parser = new ProjectParser(parserType);
         parser.parseSourcePackage(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
         graphNodeCollection.populateGraphNodes(new ArrayList<>(parser.getPackageNodes().get(Paths.get(currentDirectory.toRealPath().normalize().toString(),
@@ -163,8 +163,8 @@ class PlantUMLConverterTest {
 		expectedRelationships.add("src.controller.commands ..> src.model");
 		expectedRelationships.add("src.view ..> src.model");
 		expectedRelationships.add("src.view ..> src.controller");
-		GraphNodeCollection graphNodeCollection = new GraphMLPackageNode();
-		GraphEdgeCollection graphEdgeCollection = new GraphMLPackageEdge();
+		GraphNodeCollection graphNodeCollection = new GraphNodeCollection();
+		GraphEdgeCollection graphEdgeCollection = new GraphEdgeCollection(graphNodeCollection.getGraphNodes());
         Parser parser = new ProjectParser(parserType);
         parser.parseSourcePackage(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
         graphNodeCollection.populateGraphNodes(new ArrayList<>(parser.getPackageNodes().values()));
@@ -192,7 +192,7 @@ class PlantUMLConverterTest {
 				+ "}\n");
 		expectedDeclarations.put("src.view", "package src.view {\n"
 				+ "}\n");
-		GraphNodeCollection graphNodeCollection = new GraphMLPackageNode();
+		GraphNodeCollection graphNodeCollection = new GraphNodeCollection();
         Parser parser = new ProjectParser(parserType);
         parser.parseSourcePackage(Paths.get(currentDirectory.toRealPath() + "\\src\\test\\resources\\LatexEditor\\src"));
         graphNodeCollection.populateGraphNodes(new ArrayList<>(parser.getPackageNodes().values()));


### PR DESCRIPTION
GraphMLLeafNode && GraphMLPackageNode no longer extend GraphNodeCollection
GpraphMLLeafEdge && GraphMLPackageEdge no longer extend GraphEdgeCollection
Replaced the inheritance relationships with dependencies.
The convertNodesToGraphML method of the GraphNodeCollection class has been split into two methods, the convertLeafNodesToGraphML && the convertPackageNodesToGraphML that instantiate the classes GraphMLLeafNode && GraphMLPackageNode accordingly.
Similarly with the convertEdgesToGraphML method of the GraphEdgeCollection class.
This is the first step to the refactoring of the model in order to introduce a more robust way of representing a diagram.