### PR TITLE
Fix #41

### DIFF
--- a/src/main/java/model/diagram/PackageDiagram.java
+++ b/src/main/java/model/diagram/PackageDiagram.java
@@ -11,11 +11,11 @@ import java.util.*;
 public class PackageDiagram
 {
 
-    private final  Map<PackageVertex, Integer>                 graphNodes;
-    private        Map<PackageVertex, Set<Arc<PackageVertex>>> diagram;
-    private        Map<Path, PackageVertex>                    vertices;
-    private        Map<Integer, Pair<Double, Double>>          diagramGeometryGraphML;
-    private        DiagramGeometry                             diagramGeometry;
+    private final Map<PackageVertex, Integer>                 graphNodes;
+    private       Map<PackageVertex, Set<Arc<PackageVertex>>> diagram;
+    private       Map<Path, PackageVertex>                    vertices;
+    private       Map<Integer, Pair<Double, Double>>          diagramGeometryGraphML;
+    private       DiagramGeometry                             diagramGeometry;
 
 
     public PackageDiagram()
@@ -54,12 +54,10 @@ public class PackageDiagram
         List<PackageVertex> chosenPackages = new ArrayList<>();
         for (String chosenPackage : chosenPackagesNames)
         {
-            Optional<PackageVertex> vertex = vertices.values().stream()
-                //.filter(it -> it.getName().equals(chosenPackage))
-            	.filter(it -> it.getPath().toString().equals(chosenPackage))
-                .findFirst();
-
-            vertex.ifPresent(chosenPackages::add);
+            vertices.values().stream()
+                .filter(it -> it.getName().equals(chosenPackage))
+                .findFirst()
+                .ifPresent(chosenPackages::add);
         }
 
         return chosenPackages;

--- a/src/main/java/view/DiagramCreation.java
+++ b/src/main/java/view/DiagramCreation.java
@@ -8,6 +8,9 @@ import javafx.scene.control.MenuBar;
 import java.io.File;
 import java.util.List;
 
+import static view.FileType.PACKAGE;
+import static view.FileType.SOURCE;
+
 public class DiagramCreation
 {
 
@@ -57,7 +60,7 @@ public class DiagramCreation
             PopupWindow.createPopupInfoWindow("You have neither created a diagram nor loaded it yet!", "Error");
             return;
         }
-        if (!wereFilesChosen())
+        if (!wereAnyFilesChosen())
         {
             PopupWindow.createPopupInfoWindow("You haven't selected any files!", "Error");
             return;
@@ -123,21 +126,16 @@ public class DiagramCreation
 
     private List<String> getSelectedFiles(String diagramType)
     {
-        if (diagramType.equals("Package"))
-        {
-            return projectTreeView.getSelectedFiles(projectTreeView.getFolderFiles(), "package");
-        }
-        else
-        {
-            return projectTreeView.getSelectedFiles(projectTreeView.getJavaSourceFiles(), "java");
-        }
+        return diagramType.equals("Package") ?
+            projectTreeView.getSelectedFiles(PACKAGE) :
+            projectTreeView.getSelectedFiles(SOURCE);
     }
 
 
-    private boolean wereFilesChosen()
+    private boolean wereAnyFilesChosen()
     {
-        return !(projectTreeView.getSelectedFiles(projectTreeView.getFolderFiles(), "package").isEmpty() &&
-                 projectTreeView.getSelectedFiles(projectTreeView.getJavaSourceFiles(), "java").isEmpty());
+        return !(projectTreeView.getSelectedFiles(PACKAGE).isEmpty() &&
+                 projectTreeView.getSelectedFiles(SOURCE).isEmpty());
     }
 
 

--- a/src/main/java/view/FileType.java
+++ b/src/main/java/view/FileType.java
@@ -1,0 +1,7 @@
+package view;
+
+public enum FileType
+{
+    SOURCE,
+    PACKAGE
+}

--- a/src/main/java/view/FileUtility.java
+++ b/src/main/java/view/FileUtility.java
@@ -6,7 +6,6 @@ import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.util.Map;
 
 import static java.util.Map.entry;

--- a/src/main/java/view/ProjectTreeView.java
+++ b/src/main/java/view/ProjectTreeView.java
@@ -8,11 +8,14 @@ import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
 import javafx.scene.control.cell.CheckBoxTreeCell;
 
+import java.io.File;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+
+import static view.FileType.PACKAGE;
 
 public class ProjectTreeView
 {
@@ -90,29 +93,36 @@ public class ProjectTreeView
 
     private String getRelativePath(Path path)
     {
-        return path.normalize().toString().replace(sourceFolderPath.normalize().toString().substring(0,
-                                                                                                     sourceFolderPath.normalize().toString().lastIndexOf("/") + 1), "").replace("/", ".");
+        return path.normalize()
+            .toString()
+            .replace(sourceFolderPath.normalize()
+                         .toString()
+                         .substring(0, sourceFolderPath.normalize()
+                                           .toString()
+                                           .lastIndexOf(File.separator) + 1), "")
+            .replace(File.separator, ".");
     }
 
 
-    public List<String> getSelectedFiles(List<String> files, String fileType)
+    public List<String> getSelectedFiles(FileType fileType)
     {
+        List<String> files = fileType.equals(PACKAGE) ?
+            folderFiles :
+            javaSourceFiles;
+
         List<String> selectedFiles = new ArrayList<>();
         for (CheckBoxTreeItem<?> c : checkedItems)
         {
-            if (!files.contains((String)c.getValue()))
-            {
-                continue;
-            }
-            if (fileType.equals("java"))
-            {
-                selectedFiles.add(subtractFileExtension((String)c.getValue()));
-            }
-            else
-            {
-                selectedFiles.add(((String)c.getValue()));
+            String name = (String) c.getValue();
+            if (!files.contains(name)) continue;
+
+            switch (fileType) {
+                case SOURCE -> selectedFiles.add(subtractFileExtension(name));
+                case PACKAGE -> selectedFiles.add(name);
+                default -> throw new UnsupportedOperationException();
             }
         }
+
         return selectedFiles;
     }
 
@@ -146,18 +156,6 @@ public class ProjectTreeView
     private String subtractFileExtension(String s)
     {
         return s.substring(0, s.lastIndexOf("."));
-    }
-
-
-    public List<String> getFolderFiles()
-    {
-        return folderFiles;
-    }
-
-
-    public List<String> getJavaSourceFiles()
-    {
-        return javaSourceFiles;
     }
 
 


### PR DESCRIPTION
The description of #41 would definitely explain why there is this weirdness between Windows and Linux. However, the problem is not in the filtering part but rather in the creation of the List that we pass as an argument to that function. Instead, we change the function that converts full paths to relative paths to use system-dependent separators.