### PR TITLE
Fix paths to resource files when using the jar

### DIFF
--- a/src/main/java/model/diagram/javafx/JavaFXClassVisualization.java
+++ b/src/main/java/model/diagram/javafx/JavaFXClassVisualization.java
@@ -4,34 +4,22 @@ import com.brunomnsilva.smartgraph.graph.Digraph;
 import com.brunomnsilva.smartgraph.graph.DigraphEdgeList;
 import com.brunomnsilva.smartgraph.graph.Graph;
 import com.brunomnsilva.smartgraph.graph.Vertex;
-import com.brunomnsilva.smartgraph.graphview.SmartCircularSortedPlacementStrategy;
 import com.brunomnsilva.smartgraph.graphview.SmartGraphPanel;
-import com.brunomnsilva.smartgraph.graphview.SmartGraphProperties;
 import model.diagram.ClassDiagram;
 import model.graph.Arc;
 import model.graph.ArcType;
 import model.graph.ClassifierVertex;
 import model.graph.VertexType;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Set;
 
 public class JavaFXClassVisualization implements JavaFXVisualization
 {
 
-    public static final String DEFAULT_PROPERTIES_PATH = "styles/smartgraph.properties";
-    public static final String DEFAULT_STYLE_PATH      = "styles/smartgraph.css";
-
     private final  ClassDiagram                    classDiagram;
     private        SmartGraphPanel<String, String> graphView;
     private        Collection<Vertex<String>>      vertexCollection;
-
 
     public JavaFXClassVisualization(ClassDiagram diagram)
     {
@@ -44,29 +32,12 @@ public class JavaFXClassVisualization implements JavaFXVisualization
     {
         Graph<String, String> graph = createGraph();
         vertexCollection            = graph.vertices();
-        graphView                   = createGraphView(graph);
+        graphView                   = SmartGraphFactory.createGraphView(graph);
         setSinkVertexCustomStyle();
         return graphView;
     }
 
 
-    private static SmartGraphPanel<String, String> createGraphView(Graph<String, String> graph)
-    {
-        try (InputStream resource = JavaFXClassVisualization.class.getClassLoader().getResourceAsStream(DEFAULT_PROPERTIES_PATH))
-        {
-            SmartGraphProperties properties = new SmartGraphProperties(resource);
-
-            URL url = JavaFXClassVisualization.class.getClassLoader().getResource(DEFAULT_STYLE_PATH);
-            URI cssFile = Objects.requireNonNull(url).toURI();
-
-            return new SmartGraphPanel<>(graph, properties, new SmartCircularSortedPlacementStrategy(), cssFile);
-        }
-        catch (IOException | URISyntaxException ignored)
-        {
-            // Fallback to default paths.
-            return new SmartGraphPanel<>(graph, new SmartCircularSortedPlacementStrategy());
-        }
-    }
 
 
     private Graph<String, String> createGraph()

--- a/src/main/java/model/diagram/javafx/JavaFXPackageVisualization.java
+++ b/src/main/java/model/diagram/javafx/JavaFXPackageVisualization.java
@@ -34,7 +34,7 @@ public class JavaFXPackageVisualization implements JavaFXVisualization
     {
         Graph<String, String> graph = createGraph();
         vertexCollection = graph.vertices();
-        graphView        = new SmartGraphPanel<>(graph, new SmartCircularSortedPlacementStrategy());
+        graphView        = SmartGraphFactory.createGraphView(graph);
         setVertexCustomStyle();
 
         return graphView;

--- a/src/main/java/model/diagram/javafx/SmartGraphFactory.java
+++ b/src/main/java/model/diagram/javafx/SmartGraphFactory.java
@@ -1,0 +1,46 @@
+package model.diagram.javafx;
+
+import com.brunomnsilva.smartgraph.graph.Graph;
+import com.brunomnsilva.smartgraph.graphview.SmartCircularSortedPlacementStrategy;
+import com.brunomnsilva.smartgraph.graphview.SmartGraphPanel;
+import com.brunomnsilva.smartgraph.graphview.SmartGraphProperties;
+import util.Resources;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Objects;
+
+public class SmartGraphFactory {
+
+    public static final String DEFAULT_PROPERTIES_PATH = "styles/smartgraph.properties";
+    public static final String DEFAULT_STYLE_PATH = "styles/smartgraph.css";
+
+    /**
+     * Factory for SmartGraphPanel object creation
+     * @param graph
+     * @return
+     */
+    public static SmartGraphPanel<String, String> createGraphView(Graph<String, String> graph)
+    {
+        try
+        {
+            SmartGraphProperties properties = getSmartgraphProperties();
+            URI url = getSmartGraphStyleURI();
+            URI cssFile = Objects.requireNonNull(url);
+            return new SmartGraphPanel<>(graph, properties, new SmartCircularSortedPlacementStrategy(), cssFile);
+        }
+        catch (URISyntaxException ignored)
+        {
+            // Fallback to default paths.
+            return new SmartGraphPanel<>(graph, new SmartCircularSortedPlacementStrategy());
+        }
+    }
+
+    public static SmartGraphProperties getSmartgraphProperties() {
+        return new SmartGraphProperties(Resources.loadResourceFile(DEFAULT_PROPERTIES_PATH));
+    }
+
+    public static URI getSmartGraphStyleURI() throws URISyntaxException {
+        return Resources.getResourceURI(DEFAULT_STYLE_PATH);
+    }
+}

--- a/src/main/java/util/Resources.java
+++ b/src/main/java/util/Resources.java
@@ -1,6 +1,7 @@
 package util;
 
 import com.brunomnsilva.smartgraph.graphview.SmartGraphProperties;
+import model.diagram.javafx.JavaFXClassVisualization;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -9,11 +10,11 @@ import java.net.URISyntaxException;
 public class Resources {
 
     public static InputStream loadResourceFile(String relativePath) {
-        return Thread.currentThread().getContextClassLoader().getResourceAsStream(relativePath);
+        return Resources.class.getClassLoader().getResourceAsStream(relativePath);
     }
 
     public static URI getResourceURI(String relativePath) throws URISyntaxException {
-        return Thread.currentThread().getContextClassLoader().getResource(relativePath).toURI();
+        return Resources.class.getClassLoader().getResource(relativePath).toURI();
     }
 
 }

--- a/src/main/java/util/Resources.java
+++ b/src/main/java/util/Resources.java
@@ -1,0 +1,19 @@
+package util;
+
+import com.brunomnsilva.smartgraph.graphview.SmartGraphProperties;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class Resources {
+
+    public static InputStream loadResourceFile(String relativePath) {
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream(relativePath);
+    }
+
+    public static URI getResourceURI(String relativePath) throws URISyntaxException {
+        return Thread.currentThread().getContextClassLoader().getResource(relativePath).toURI();
+    }
+
+}


### PR DESCRIPTION
Seems like we were using the default constructor of `SmartGraphPanel` which will try to find the paths to the smartgraph properties and css files. We can instead load the resources our selves and use a constructor that takes these as parameters. This seems more reliable, especially when using the jar.
Tested by building the jar with the dependencies using,
```java
./mvnw -B package --file pom.xml --update-snapshots verify -DskipTests
```
and then running the jar.