### PR TITLE
Fixed NPE for unknown modifier type

### DIFF
--- a/src/main/java/parser/ASTUtil.java
+++ b/src/main/java/parser/ASTUtil.java
@@ -1,19 +1,19 @@
 package parser;
 
 import com.github.javaparser.ast.Modifier;
-
 import java.util.List;
 
 public class ASTUtil {
 
-    public static List<Modifier> filterVisibilityModifiers(List<Modifier> allModifiers){
-        return allModifiers
-                .stream()
-                .filter(modifier -> {
-                    Modifier.Keyword keyword = modifier.getKeyword();
-                    return keyword.equals(Modifier.Keyword.PUBLIC) ||
-                            keyword.equals(Modifier.Keyword.PRIVATE) ||
-                            keyword.equals(Modifier.Keyword.PROTECTED);
-                }).toList();
+    public static List<Modifier> filterVisibilityModifiers(List<Modifier> allModifiers) {
+        return allModifiers.stream()
+                .filter(
+                        modifier -> {
+                            Modifier.Keyword keyword = modifier.getKeyword();
+                            return keyword.equals(Modifier.Keyword.PUBLIC)
+                                    || keyword.equals(Modifier.Keyword.PRIVATE)
+                                    || keyword.equals(Modifier.Keyword.PROTECTED);
+                        })
+                .toList();
     }
 }

--- a/src/main/java/parser/ASTUtil.java
+++ b/src/main/java/parser/ASTUtil.java
@@ -1,0 +1,19 @@
+package parser;
+
+import com.github.javaparser.ast.Modifier;
+
+import java.util.List;
+
+public class ASTUtil {
+
+    public static List<Modifier> filterVisibilityModifiers(List<Modifier> allModifiers){
+        return allModifiers
+                .stream()
+                .filter(modifier -> {
+                    Modifier.Keyword keyword = modifier.getKeyword();
+                    return keyword.equals(Modifier.Keyword.PUBLIC) ||
+                            keyword.equals(Modifier.Keyword.PRIVATE) ||
+                            keyword.equals(Modifier.Keyword.PROTECTED);
+                }).toList();
+    }
+}

--- a/src/main/java/parser/FileVisitor.java
+++ b/src/main/java/parser/FileVisitor.java
@@ -1,5 +1,8 @@
 package parser;
 
+import static parser.tree.ModifierType.PACKAGE_PRIVATE;
+import static parser.tree.NodeType.ENUM;
+
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
@@ -12,10 +15,6 @@ import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import parser.tree.*;
-
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -23,9 +22,9 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import static parser.tree.ModifierType.PACKAGE_PRIVATE;
-import static parser.tree.NodeType.ENUM;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import parser.tree.*;
 
 /**
  * This class is responsible for the creation of the AST of a Java source file using {@link
@@ -214,7 +213,8 @@ public class FileVisitor {
 
             for (VariableDeclarator variable : fieldDeclaration.getVariables()) {
 
-                List<Modifier> visibilityModifiers = ASTUtil.filterVisibilityModifiers(fieldDeclaration.getModifiers());
+                List<Modifier> visibilityModifiers =
+                        ASTUtil.filterVisibilityModifiers(fieldDeclaration.getModifiers());
 
                 ModifierType modifierType =
                         visibilityModifiers.isEmpty()
@@ -260,7 +260,8 @@ public class FileVisitor {
         public void visit(MethodDeclaration methodDeclaration, Void arg) {
             super.visit(methodDeclaration, arg);
 
-            List<Modifier> visibilityModifiers = ASTUtil.filterVisibilityModifiers(methodDeclaration.getModifiers());
+            List<Modifier> visibilityModifiers =
+                    ASTUtil.filterVisibilityModifiers(methodDeclaration.getModifiers());
 
             ModifierType modifierType =
                     visibilityModifiers.isEmpty()

--- a/src/main/java/parser/FileVisitor.java
+++ b/src/main/java/parser/FileVisitor.java
@@ -14,7 +14,6 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.jdt.core.dom.AST;
 import parser.tree.*;
 
 import java.io.FileNotFoundException;
@@ -26,7 +25,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static parser.tree.ModifierType.PACKAGE_PRIVATE;
-import static parser.tree.ModifierType.PUBLIC;
 import static parser.tree.NodeType.ENUM;
 
 /**

--- a/src/main/java/parser/FileVisitor.java
+++ b/src/main/java/parser/FileVisitor.java
@@ -267,10 +267,6 @@ public class FileVisitor {
                             ? PACKAGE_PRIVATE
                             : ModifierType.get(methodDeclaration.getModifiers().get(0).toString());
 
-            if (modifierType == null){
-                System.out.println(methodDeclaration.getNameAsString());
-            }
-
             Map<String, String> parameters =
                     methodDeclaration.getParameters().stream()
                             .collect(


### PR DESCRIPTION
The program crashes (NPE) due to the assumption that in cases of default visibility (package private) in methods or fields, the list of modifiers is empty. This does not hold, since we can have other modifiers, e.g. static combined with default visibility.

The pull request fixes the bug.